### PR TITLE
Add Cross-Platform Support for File Watching and Command Execution(Windows OS🪟)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,7 @@
 module github.com/kamandlou/watcher
 
-go 1.23.0
+go 1.23.1
 
-require (
-	github.com/fsnotify/fsnotify v1.7.0 // direct
-	golang.org/x/sys v0.4.0 // indirect
-)
+require github.com/fsnotify/fsnotify v1.7.0 // direct
+
+require golang.org/x/sys v0.4.0 // indirect


### PR DESCRIPTION
This pull request introduces several enhancements to ensure cross-platform compatibility for the file watching and command execution functionality of the project. The primary changes include:

Cross-Platform Command Execution:
Modified the ExecuteCommand function to support both Unix-like systems and Windows🪟.

Path Handling Adjustments:
Ensured that file paths are formatted correctly for the operating system by using filepath.FromSlash().

Also:
Delete redundant break statement (switch mode)

Update go.mod file go 1.23.0 -> go 1.23.1